### PR TITLE
Fixed custom OpenAI implementation to use the correct base URLs

### DIFF
--- a/src/component/workspace/Workspace.svelte
+++ b/src/component/workspace/Workspace.svelte
@@ -71,7 +71,7 @@
 		}),
 	)
 	let embeddingClient: EmbeddingClient = $derived(
-		new OpenAIEmbeddingClient($settingsStore.openAIApiKey),
+		new OpenAIEmbeddingClient($settingsStore.openAIApiKey, baseURL=$settingsStore.customEmbeddingModelUrl),
 	)
 	let retriever = $derived(
 		new EmbeddingVectorRetriever(vectorStore, embeddingClient, {

--- a/src/component/workspace/Workspace.svelte
+++ b/src/component/workspace/Workspace.svelte
@@ -71,7 +71,7 @@
 		}),
 	)
 	let embeddingClient: EmbeddingClient = $derived(
-		new OpenAIEmbeddingClient($settingsStore.openAIApiKey, baseURL=$settingsStore.customEmbeddingModelUrl),
+		new OpenAIEmbeddingClient($settingsStore.customEmbeddingModelApiKey || $settingsStore.openAIApiKey),
 	)
 	let retriever = $derived(
 		new EmbeddingVectorRetriever(vectorStore, embeddingClient, {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -269,6 +269,9 @@ export class LlmSettingTab extends PluginSettingTab {
 							value += "/"
 						}
 						this.plugin.settings.customEmbeddingModelUrl = value
+						if (!this.plugin.settings.customEmbeddingModelUrl || !this.plugin.settings.customEmbeddingModelApiKey) {
+							this.plugin.settings.customEmbeddingModelName = ""
+						}
 						await this.plugin.saveSettings()
 			  }),
 			)
@@ -283,6 +286,9 @@ export class LlmSettingTab extends PluginSettingTab {
 						.setValue(this.plugin.settings.customEmbeddingModelApiKey)
 						.onChange(async (value) => {
 							this.plugin.settings.customEmbeddingModelApiKey = value
+							if (!this.plugin.settings.customEmbeddingModelUrl || !this.plugin.settings.customEmbeddingModelApiKey) {
+								this.plugin.settings.customEmbeddingModelName = ""
+							}
 							await this.plugin.saveSettings()
 				}),
 				)

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -101,7 +101,7 @@ export class LlmSettingTab extends PluginSettingTab {
 		if (this.plugin.settings.customEmbeddingModelUrl && this.plugin.settings.customEmbeddingModelApiKey)
 			new Setting(containerEl)
 			.setName("Model for embeddings")
-			.setDesc("The model used to generate embeddings (this must be an embeddings model!)")
+			.setDesc("The model used to generate embeddings (this must be an embedding model!)")
 			.addDropdown((dropdown) => {
 				dropdown
 					.addOptions(this.embeddingModelOptions())
@@ -240,23 +240,26 @@ export class LlmSettingTab extends PluginSettingTab {
 						this.plugin.settings.customModelUrl = value
 						await this.plugin.saveSettings()
 						this.fetchAvailableModels();
+						if (this.fetchedModels)
+							new Notice(`Fetched ${this.fetchedModels.length} models from custom endpoint`);
 			  }),
 			)
-		
-		if (this.plugin.settings.customModelUrl)
-			new Setting(containerEl)
-				.setName("API Key")
-				.setDesc("Key for your custom endpoint")
-				.addText(text =>
-					text
-						.setPlaceholder("sk-custom-...")
-						.setValue(this.plugin.settings.customModelApiKey)
-						.onChange(async (value) => {
-							this.plugin.settings.customModelApiKey = value
-							await this.plugin.saveSettings()
-							this.fetchAvailableModels();
-				}),
-				)
+
+		new Setting(containerEl)
+			.setName("API Key")
+			.setDesc("Key for your custom endpoint")
+			.addText(text =>
+				text
+					.setPlaceholder("sk-custom-...")
+					.setValue(this.plugin.settings.customModelApiKey)
+					.onChange(async (value) => {
+						this.plugin.settings.customModelApiKey = value
+						await this.plugin.saveSettings()
+						this.fetchAvailableModels();
+						if (this.fetchedModels)
+							new Notice(`Fetched ${this.fetchedModels.length} models from custom endpoint`);
+			}),
+			)
 
 		new Setting(containerEl)
 			.setName("Embedding API Base URL")
@@ -275,6 +278,8 @@ export class LlmSettingTab extends PluginSettingTab {
 						}
 						await this.plugin.saveSettings()
 						this.fetchAvailableModels();
+						if (this.fetchedEmbeddingModels)
+							new Notice(`Fetched ${this.fetchedEmbeddingModels.length} embedding models from custom endpoint`);
 			  }),
 			)
 
@@ -292,6 +297,8 @@ export class LlmSettingTab extends PluginSettingTab {
 						}
 						await this.plugin.saveSettings()
 						this.fetchAvailableModels();
+						if (this.fetchedEmbeddingModels)
+							new Notice(`Fetched ${this.fetchedEmbeddingModels.length} embedding models from custom endpoint`);
 			}),
 			)
 
@@ -400,7 +407,6 @@ export class LlmSettingTab extends PluginSettingTab {
 
 				const response = await client.models.list();
 				this.fetchedModels = response.data.map(m => m.id);
-				new Notice(`Fetched ${this.fetchedModels.length} models from custom endpoint`);
 				this.display(); // Refresh UI to show new models
 			} catch (error) {
 				console.error("Model fetch error:", error);
@@ -416,7 +422,6 @@ export class LlmSettingTab extends PluginSettingTab {
 
 				const response = await client.models.list();
 				this.fetchedEmbeddingModels = response.data.map(m => m.id);
-				new Notice(`Fetched ${this.fetchedModels.length} models from custom endpoint`);
 				this.display(); // Refresh UI to show new models
 			} catch (error) {
 				console.error("Model fetch error:", error);

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -214,7 +214,7 @@ export class LlmSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.customModelName)
 					.onChange(async (value) => {
 						this.plugin.settings.customModelName = value
-						await this.plugin.saveSettings()		
+						await this.plugin.saveSettings()
 			  }),
 			)			
 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -4,6 +4,8 @@ import { DEFAULT_SYSTEM_PROMPT } from "./prompts"
 import { Pruner } from "src/storage/pruner"
 import { logger } from "src/utils/logger"
 
+import OpenAI from "openai"
+
 export interface LlmPluginSettings {
 	openAIApiKey: string
 	anthropicApikey: string
@@ -384,8 +386,6 @@ export class LlmSettingTab extends PluginSettingTab {
 					})
 			})
 	}
-}
-
     private modelOptions(): Record<string, string> {
         const options = new Map<string, string>();
         
@@ -420,3 +420,6 @@ export class LlmSettingTab extends PluginSettingTab {
             console.error("Model fetch error:", error);
         }
     }
+}
+
+

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -213,32 +213,6 @@ export class LlmSettingTab extends PluginSettingTab {
 		.setDesc("Bring your own model! Connect any OpenAI-compatible LLM")
 		.setHeading();
 		  
-		new Setting(containerEl)
-			.setName("Conversation Model Name")
-			.setDesc("Refresh the settings menu to display the custom chat model in the dropdown list.")
-			.addText((text) => 
-				text
-					.setPlaceholder("Custom-model")
-					.setValue(this.plugin.settings.customModelName)
-					.onChange(async (value) => {
-						this.plugin.settings.customModelName = value
-						await this.plugin.saveSettings()
-			  }),
-			)			
-
-		new Setting(containerEl)
-			.setName("Note Context Model Name")
-			.setDesc("Refresh the settings menu to display the custom chat model in the dropdown list.")
-			.addText((text) => 
-				text
-					.setPlaceholder("Custom Note Taking model")
-					.setValue(this.plugin.settings.customNoteModelName)
-					.onChange(async (value) => {
-						this.plugin.settings.customNoteModelName = value
-						await this.plugin.saveSettings()		
-			  }),
-			)			
-		  
 
 
 		new Setting(containerEl)

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -254,7 +254,6 @@ export class LlmSettingTab extends PluginSettingTab {
 							this.plugin.settings.customModelApiKey = value
 							await this.plugin.saveSettings()
 							this.fetchAvailableModels();
-							await this.display();
 				}),
 				)
 

--- a/src/llm-features/client.ts
+++ b/src/llm-features/client.ts
@@ -8,27 +8,31 @@ import { settingsStore } from "../utils/obsidian"
 export const llmClient = derived<Writable<LlmPluginSettings>, StreamingChatCompletionClient>(
     settingsStore,
     ($settingsStore) => {
-        const model = $settingsStore.questionAndAnswerModel
+        const model = $settingsStore.questionAndAnswerModel;
 
-		// Custom model check.
-        if ($settingsStore.customModelName && model === $settingsStore.customModelName) {
+        // Custom endpoint takes priority if configured
+        if ($settingsStore.customModelUrl) {
             return new OpenAIChatCompletionClient(
                 $settingsStore.customModelApiKey,
                 model,
-                $settingsStore.customModelUrl || undefined
-            )
+                $settingsStore.customModelUrl
+            );
         }
-		// Standard OpenAI/Anthropic model handling.
+
+        // Standard model handling
         if (model.startsWith("gpt")) {
             return new OpenAIChatCompletionClient(
                 $settingsStore.openAIApiKey,
                 model
-            )
+            );
         } else if (model.startsWith("claude")) {
-            return new AnthropicChatCompletionClient($settingsStore.anthropicApikey, model)
+            return new AnthropicChatCompletionClient(
+                $settingsStore.anthropicApikey,
+                model
+            );
         }
 
-        throw new Error(`Unsupported model: ${model}`)
-    },
-)
+        throw new Error(`Unsupported model: ${model}`);
+    }
+);
 

--- a/src/rag/llm/openai.ts
+++ b/src/rag/llm/openai.ts
@@ -146,7 +146,7 @@ function temperature(t: Temperature): number {
 	}
 }
 
-const IMPROVE_QUERY_MODEL = get(settingsStore)?.customModelName || "gpt-4o-mini-2024-07-18"
+const IMPROVE_QUERY_MODEL = get(settingsStore)?.noteContextModel || "gpt-4o-mini-2024-07-18"
 const IMPROVE_QUERY_TEMP = 0.1
 const EMBEDDING_MODEL = "text-embedding-3-small"
 const customEmbeddingModel = get(settingsStore)?.customEmbeddingModelName || EMBEDDING_MODEL

--- a/src/rag/llm/openai.ts
+++ b/src/rag/llm/openai.ts
@@ -23,11 +23,11 @@ export class OpenAIChatCompletionClient implements StreamingChatCompletionClient
 
 	constructor(apiKey: string, model: string, baseURL?: string) {
 		this.client = new OpenAI({
-			apiKey,
+			apiKey: get(settingsStore).customModelApiKey || undefined,
 			baseURL: get(settingsStore).customModelUrl || undefined,
 			dangerouslyAllowBrowser: true 
 		})
-		this.apiKey = apiKey
+		this.apiKey = get(settingsStore).customModelApiKey
 		this.model = model
 	}
 
@@ -153,6 +153,7 @@ const customEmbeddingModel = get(settingsStore)?.customEmbeddingModelName || EMB
 
 export class OpenAIEmbeddingClient implements EmbeddingClient {
 	private client: OpenAI | undefined
+	private llm_client: OpenAI | undefined
 	private apiKey: string
 	private model: string
 	private improveQueryModel: string
@@ -183,19 +184,14 @@ export class OpenAIEmbeddingClient implements EmbeddingClient {
     }
 
 	public async initializeClient() {
-        this.client = new OpenAI({ apiKey: this.apiKey, baseURL: this.baseURL, dangerouslyAllowBrowser: true })
-        console.log("[Embedding] Initialized client with base URL:", this.baseURL)
+        this.client = new OpenAI({ apiKey: get(settingsStore).customEmbeddingModelApiKey || this.apiKey, baseURL: get(settingsStore).customEmbeddingModelUrl || undefined, dangerouslyAllowBrowser: true })
+		this.llm_client = new OpenAI({ apiKey: get(settingsStore).customModelApiKey || this.apiKey, baseURL: get(settingsStore).customModelUrl || undefined, dangerouslyAllowBrowser: true })
 	}
 
 	async embedNode(node: Node): Promise<number[]> {
 		if (!this.client) {
 			throw new Error("OpenAI client not initialized yet.  Please wait for settings to load.")
 		}
-
-		console.log("[Embedding] Using model:", this.model) // debugging line
-		console.log("[Embedding] Using base URL:", this.baseURL) // debugging line
-		console.log("[Embedding] Using API Key:", this.apiKey) // debugging line
-		console.log("[Embedding] Using improveQueryModel:", this.improveQueryModel) // debugging line
 
 		if (this.apiKey === "") {
 			throw new Error(
@@ -255,7 +251,10 @@ export class OpenAIEmbeddingClient implements EmbeddingClient {
 		if (!this.client) {
 			throw new Error("OpenAI client not initialized yet. Please wait for settings to load.");
 		}
-		const completion = await this.client.chat.completions.create({
+		if (!this.llm_client) {
+			throw new Error("OpenAI LLM client not initialized yet. Please wait for settings to load.");
+		}
+		const completion = await this.llm_client.chat.completions.create({
 			messages,
 			model: this.improveQueryModel,
 			temperature: IMPROVE_QUERY_TEMP,


### PR DESCRIPTION
Also removed the custom model name sections, instead calling the /v1/models GET endpoint to populate the dropdowns at the beginning of the page.